### PR TITLE
修改python版本的脚本,自动添加和删除DNS记录,解决同时多个子域名的问题

### DIFF
--- a/python-version/alydns.py
+++ b/python-version/alydns.py
@@ -179,14 +179,15 @@ if __name__ == '__main__':
 
    
     #print(sys.argv)
-    file_name, certbot_domain, acme_challenge, certbot_validation = sys.argv
+    file_name, cmd, certbot_domain, acme_challenge, certbot_validation = sys.argv
 
     domain = AliDns(ACCESS_KEY_ID, ACCESS_KEY_SECRET, certbot_domain)
-    data = domain.describe_domain_records()
-    record_list = data["DomainRecords"]["Record"]
-    if record_list:
-        for item in record_list:
-            if acme_challenge == item['RR']:
-                domain.delete_domain_record(item['RecordId'])
-
-    domain.add_domain_record("TXT", acme_challenge, certbot_validation)
+    if cmd == "add":
+        domain.add_domain_record("TXT", acme_challenge, certbot_validation)
+    elif cmd == "delete":
+        data = domain.describe_domain_records()
+        record_list = data["DomainRecords"]["Record"]
+        if record_list:
+            for item in record_list:
+                if (item['RR'] == acme_challenge and item['Value'] == certbot_validation):
+                    domain.delete_domain_record(item['RecordId'])

--- a/python-version/au.sh
+++ b/python-version/au.sh
@@ -2,21 +2,27 @@
 
 
 path=$(cd `dirname $0`; pwd)
+cmd=$1
 
 echo $path"/alydns.py"
 
 # 调用 python 脚本，自动设置 DNS TXT 记录。
-# 第一个参数：需要为那个域名设置 DNS 记录
-# 第二个参数：需要为具体那个 RR 设置
-# 第三个参数: letsencrypt 动态传递的 RR 值
+# 第一个参数：命令 add 和 delete
+# 第二个参数：需要为那个域名设置 DNS 记录
+# 第三个参数: 需要为具体那个 RR 设置
+# 第四个参数: letsencrypt 动态传递的 RR 值
 
-echo $CERTBOT_DOMAIN "_acme-challenge" $CERTBOT_VALIDATION
+echo $cmd $CERTBOT_DOMAIN "_acme-challenge" $CERTBOT_VALIDATION
 
-# 根据自己机器的python环境选择python版本
-python  $path"/alydns.py"  $CERTBOT_DOMAIN "_acme-challenge"  $CERTBOT_VALIDATION >"/var/log/certdebug.log"
+if [[ -n "$cmd" ]]; then
+    # 根据自己机器的python环境选择python版本
+    python $path"/alydns.py" $cmd $CERTBOT_DOMAIN "_acme-challenge" $CERTBOT_VALIDATION >"/var/log/certdebug.log"
 
-# DNS TXT 记录刷新时间
-/bin/sleep 20
+    if [[ "$cmd" == "add" ]]; then
+        # DNS TXT 记录刷新时间
+        /bin/sleep 10
+    fi
+fi
 
 echo "END"
 ###


### PR DESCRIPTION
只修改了python的，CentOS 7.6、Python 2.7 运行正常
命令做如下修改即可：
```
--manual-auth-hook "/脚本目录/au.sh add" --manual-cleanup-hook "/脚本目录/au.sh delete"
```