### PR TITLE
修复 Python 脚本域名提取错误

### DIFF
--- a/python-version/alydns.py
+++ b/python-version/alydns.py
@@ -8,7 +8,7 @@ import random
 import string
 import json
 import sys
-import os 
+import os
 
 pv = "python2"
 #python2
@@ -32,8 +32,7 @@ class AliDns:
     @staticmethod
     def getDomain(domain):
         domain_parts = domain.split('.')
- 
-        
+
         if len(domain_parts) > 2:
             dirpath = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
             domainfile = dirpath + "/domain.ini"
@@ -43,11 +42,8 @@ class AliDns:
                     val = line.strip()
                     domainarr.append(val)
 
-            #rootdomain = '.'.join(domain_parts[-(2 if domain_parts[-1] in {"co.jp", "com.tw", "net", "com", "com.cn", "org", "cn", "gov", "net.cn", "io", "top", "me", "int", "edu", "link"} else 3):])
-            rootdomain = '.'.join(domain_parts[-(2 if domain_parts[-1] in
-                                                 domainarr else 3):])
-            selfdomain = domain.split(rootdomain)[0]
-            return (selfdomain[0:len(selfdomain)-1], rootdomain)
+            index = -3 if '.'.join(domain_parts[-2:]).lower() in domainarr else -2
+            return ('.'.join(domain_parts[:index]), '.'.join(domain_parts[index:]))
         return ("", domain)
 
     @staticmethod

--- a/python-version/godaddydns.py
+++ b/python-version/godaddydns.py
@@ -2,7 +2,7 @@
 
 import json
 import sys
-import os 
+import os
 
 class GodaddyDns:
     def __init__(self, access_key_id, access_key_secret, domain_name):
@@ -22,9 +22,8 @@ class GodaddyDns:
                     val = line.strip()
                     domainarr.append(val)
 
-            rootdomain = '.'.join(domain_parts[-(2 if domain_parts[-1] in domainarr else 3): ])
-            selfdomain = domain.split(rootdomain)[0]
-            return (selfdomain[0:len(selfdomain)-1], rootdomain)
+            index = -3 if '.'.join(domain_parts[-2:]).lower() in domainarr else -2
+            return ('.'.join(domain_parts[:index]), '.'.join(domain_parts[index:]))
         return ("", domain)
 
     def curl(self, url, data, method):
@@ -57,7 +56,7 @@ class GodaddyDns:
         else :
             import urllib.request
             from urllib.error import URLError, HTTPError
-            
+
             httpdata = json.dumps(data).encode('utf-8')
 
             req = urllib.request.Request(url=url, data=httpdata, method=method)

--- a/python-version/txydns.py
+++ b/python-version/txydns.py
@@ -97,7 +97,7 @@ class Cns:
     @staticmethod
     def getDomain(domain):
         domain_parts = domain.split('.')
- 
+
         if len(domain_parts) > 2:
             dirpath = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
             domainfile = dirpath + "/domain.ini"
@@ -107,9 +107,8 @@ class Cns:
                     val = line.strip()
                     domainarr.append(val)
 
-            rootdomain = '.'.join(domain_parts[-(2 if domain_parts[-1] in domainarr else 3): ])
-            selfdomain = domain.split(rootdomain)[0]
-            return (selfdomain[0:len(selfdomain)-1], rootdomain)
+            index = -3 if '.'.join(domain_parts[-2:]).lower() in domainarr else -2
+            return ('.'.join(domain_parts[:index]), '.'.join(domain_parts[index:]))
         return ("", domain)
 
     def create(self, domain, name, _type, value):


### PR DESCRIPTION
### 关联 Issue

#52 

### 问题描述

当 domain.ini 中含有一个二级域名，且它的顶级域已经在列表中定义。此时 Python 脚本调用 getDomain 方法域名没有正确提取

如输入 `example.com.cn` 至 getDomain, 其会输出 `('example', 'com.cn')`

### 修改描述

调整根域名匹配方式，使用二级域名加顶级域名去匹配根域名列表，若匹配的上，则取上前一个域名，作为主域名，否则当前二级域加顶级域作为主域名

### 测试

1. alydns, godaddydns, txydns 三个 python 脚本测试 `example.cn`, `example.com.cn`, `m.example.com.cn` 正常

2. python2.7 python3.7 测试脚本正常

已测试