### PR TITLE
Update Aliyun AccessKey document link

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ $ chmod 0777 au.sh
 
 这个 API 密钥什么意思呢？由于需要通过 API 操作阿里云 DNS, 腾讯云 DNS 的记录，所以需要去域名服务商哪儿获取 API 密钥，然后配置在 au.sh 文件中:
 
-- ALY_KEY 和 ALY_TOKEN：阿里云 [API key 和 Secrec 官方申请文档](https://help.aliyun.com/knowledge_detail/38738.html)。
+- ALY_KEY 和 ALY_TOKEN：阿里云 [API key 和 Secrec 官方申请文档](https://help.aliyun.com/document_detail/117142.html)。
 - TXY_KEY 和 TXY_TOKEN：腾讯云 [API 密钥官方申请文档](https://console.cloud.tencent.com/cam/capi)。
 - HWY_KEY 和 HWY_TOKEN: 华为云 [API 密钥官方申请文档](https://support.huaweicloud.com/devg-apisign/api-sign-provide.html)
 - GODADDY_KEY 和 GODADDY_TOKEN：GoDaddy [API 密钥官方申请文档](https://developer.godaddy.com/getstarted)。

--- a/end-share.sh
+++ b/end-share.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+rm -f /root/sgfs/upload/cert.zip

--- a/get-cert.sh
+++ b/get-cert.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+/usr/local/bin/certbot-auto certonly --non-interactive --manual-public-ip-logging-ok --agree-tos -m z@limme.net  -d *.limme.net --manual --preferred-challenges dns --manual-auth-hook "/root/certbot-aliyun/au.sh php aly add" --manual-cleanup-hook "/root/certbot-aliyun/au.sh php aly clean"

--- a/ready-share.sh
+++ b/ready-share.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+cd /etc/letsencrypt/live/limme.net/
+zip -e -r /root/sgfs/upload/cert.zip  *

--- a/renew-cert.sh
+++ b/renew-cert.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# Haven't tested yet
+
+./certbot-auto renew --non-interactive --manual-public-ip-logging-ok --agree-tos  --manual --preferred-challenges dns --manual-auth-hook "/root/certbot-aliyun//au.sh php aly add" --manual-cleanup-hook "/root/certbot-aliyun//au.sh php aly clean"


### PR DESCRIPTION
原Repo Readme中关于阿里云的链接是失效的
另外希望在Readme中包含必要的certbot配置信息，现在Certbot官网说签发wildcard证书必须在docker中运行，实际上至少结合这个repo是不需要docker版的certbot的，新手如我遇到这些问题容易绕远路。