### PR TITLE
阿里云的 dns 申请 支持诸如 com.hk, com.cn 类型的 复合域名。

### DIFF
--- a/domain.ini
+++ b/domain.ini
@@ -15,4 +15,5 @@ edu
 link
 uk
 hk
+com.hk
 shop

--- a/python-version/alydns.py
+++ b/python-version/alydns.py
@@ -42,12 +42,12 @@ class AliDns:
                 for line in f:
                     val = line.strip()
                     domainarr.append(val)
-
-            #rootdomain = '.'.join(domain_parts[-(2 if domain_parts[-1] in {"co.jp", "com.tw", "net", "com", "com.cn", "org", "cn", "gov", "net.cn", "io", "top", "me", "int", "edu", "link"} else 3):])
-            rootdomain = '.'.join(domain_parts[-(2 if domain_parts[-1] in
-                                                 domainarr else 3):])
-            selfdomain = domain.split(rootdomain)[0]
-            return (selfdomain[0:len(selfdomain)-1], rootdomain)
+            domainarr = sorted(domainarr, key=len, reverse=True)
+            for dm in domainarr:
+                if domain.endswith("." + dm):
+                    rootdomain = ".".join(domain_parts[-1 - len(dm.split(".")):])
+		            selfdomain = domain.split(rootdomain)[0]
+		            return (selfdomain[0:len(selfdomain)-1], rootdomain)
         return ("", domain)
 
     @staticmethod


### PR DESCRIPTION
.com.cn 会被判定为 .cn，.com.hk 会被判定为.hk。 简单的修复了此bug。